### PR TITLE
Game Components as data

### DIFF
--- a/articular-es/src/main/java/articular/core/Entity.java
+++ b/articular-es/src/main/java/articular/core/Entity.java
@@ -32,7 +32,7 @@
 package articular.core;
 
 import articular.core.component.Component;
-import java.util.Map;
+import java.util.Collection;
 
 /**
  * Represents a game entity with some {@link Component}s.
@@ -46,49 +46,30 @@ import java.util.Map;
  * A Map of components must be provided via a DI pattern.
  * </p>
  *
- * @param <I> the input type of the game loop
+ * @param <T> the type of the game component objects
  * @author pavl_g
  */
-public interface Entity<I> extends Component<I> {
+public interface Entity<T> extends Component<T> {
 
     /**
-     * A Map of game entity components to be provided.
+     * A Collection of game entity components to be provided.
      *
-     * <p>
-     * Override and provide a map of components for this entity via the DI pattern.
-     * </p>
-     *
-     * @return a map of components by their identifiers (not null)
+     * @return a collection of game entity's components
      */
-    Map<? super Number, Component<I>> getComponents();
+    Collection<Component<T>> getComponents();
+
+    /**
+     * Retrieves a game entity's component by its identifier.
+     *
+     * @param id the component identifier
+     * @return a game entity component or a game sub-entity
+     */
+    Component<T> getComponent(Component.Id id);
 
     /**
      * Retrieves the name of this entity.
      *
-     * <p>
-     * Override and provide a name for this entity via the DI pattern.
-     * </p>
-     *
-     * @return the name of this entity (not null)
+     * @return the name of this entity (nullable)
      */
     String getName();
-
-    /**
-     * Retrieves a specific game entity component by its identifier.
-     *
-     * @param id the game entity component identifier
-     * @return a game entity component or null if it doesn't exist (nullable)
-     */
-    default Component<I> getComponent(Component.Id id) {
-        return getComponents().get(id);
-    }
-
-    /**
-     * Updates this game entity through updating its components.
-     *
-     * @param input the input to the game loop pattern
-     */
-    default void update(I input) {
-        getComponents().forEach((id, component) -> component.update(input));
-    }
 }

--- a/articular-es/src/main/java/articular/core/Entity.java
+++ b/articular-es/src/main/java/articular/core/Entity.java
@@ -46,17 +46,16 @@ import java.util.Collection;
  * A Map of components must be provided via a DI pattern.
  * </p>
  *
- * @param <T> the type of the game component objects
  * @author pavl_g
  */
-public interface Entity<T> extends Component<T> {
+public interface Entity extends Component {
 
     /**
      * A Collection of game entity components to be provided.
      *
      * @return a collection of game entity's components
      */
-    Collection<Component<T>> getComponents();
+    Collection<Component> getComponents();
 
     /**
      * Retrieves a game entity's component by its identifier.
@@ -64,7 +63,7 @@ public interface Entity<T> extends Component<T> {
      * @param id the component identifier
      * @return a game entity component or a game sub-entity
      */
-    Component<T> getComponent(Component.Id id);
+    Component getComponent(Component.Id id);
 
     /**
      * Retrieves the name of this entity.

--- a/articular-es/src/main/java/articular/core/UpdatableEntity.java
+++ b/articular-es/src/main/java/articular/core/UpdatableEntity.java
@@ -31,52 +31,26 @@
 
 package articular.core;
 
-import articular.core.component.Component;
-import articular.util.EntityComponentManager;
-import java.util.Map;
+import articular.core.component.UpdatableComponent;
 
 /**
- * Defines a base implementation for the {@link Entity}, the container
- * object of the articular-es API.
+ * Provides an update logic for the game entity.
  *
- * @param <I> the type of the input to the game loop pattern
+ * @param <T> the type of game components' data
+ * @param <I> the type of the input to the game loop (used by the update method)
  */
-public abstract class BaseGameEntity<I> implements Entity<I> {
+public interface UpdatableEntity<T, I> extends Entity<T> {
 
     /**
-     * The name for this entity utilized by the
-     * {@link EntityComponentManager}.
-     */
-    protected String name;
-
-    /**
-     * A map for the Game entity components registered to this entity.
-     */
-    protected final Map<? super Number, Component<I>> components;
-
-    /**
-     * Instantiates a game entity with a name and game entity components.
+     * Updates this game entity through updating its components.
      *
-     * <p>
-     * Subclasses overriding the default constructor should
-     * provide a call to this constructor or an acceptable alternative.
-     * </p>
-     *
-     * @param name the name of this game entity
-     * @param components a map of game entity components
+     * @param input the input to the game loop pattern
      */
-    public BaseGameEntity(String name, Map<? super Number, Component<I>> components) {
-        this.name = name;
-        this.components = components;
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public Map<? super Number, Component<I>> getComponents() {
-        return components;
+    default void update(I input) {
+        getComponents().forEach((component) -> {
+            if (component instanceof UpdatableComponent) {
+                ((UpdatableComponent<T, I>) component).update(input);
+            }
+        });
     }
 }

--- a/articular-es/src/main/java/articular/core/component/Component.java
+++ b/articular-es/src/main/java/articular/core/component/Component.java
@@ -33,43 +33,37 @@ package articular.core.component;
 
 import articular.core.Entity;
 import articular.util.EntityComponentManager;
+import java.lang.reflect.Field;
 
 /**
- * A template representing a Game {@link Entity} component.
+ * A template representing a Game {@link Entity} housing data objects.
  *
- * @param <I> the input type to the game loop pattern
+ * @param <T> the type of the component object data in memory
  * @author pavl_g
  */
-public interface Component<I> {
+@SuppressWarnings("unchecked")
+public interface Component<T> {
 
     /**
-     * Retrieves the entity that encapsulates this component.
+     * Retrieves all the declared fields in an array of {@link Field}.
      *
-     * <p>
-     * Override this method and use the DI pattern to link the component
-     * entity here.
-     * </p>
-     *
-     * @return the entity encapsulating this game component
+     * @return the data fields of this component wrapped in an array of Field pointers
      */
-    Entity<I> getEntity();
+    default Field[] getData() {
+        return getClass().getDeclaredFields();
+    }
 
     /**
-     * Updates this game component with an abstract input.
+     * Retrieves a data field by its name in a field pointer.
      *
-     * <p>
-     * Override this method and use the Game loop pattern to link the
-     * original game states to this component via the game {@link Entity}s.
-     * </p>
-     *
-     * <p>
-     * This method is dispatched by {@link Entity#update(Object)}, never call
-     * it manually!
-     * </p>
-     *
-     * @param input an input to perform the update on
+     * @param fieldName the field name in the component class
+     * @return a reference object to the required field
+     * @throws NoSuchFieldException if the submitted field is not found in this component
+     * @throws IllegalAccessException if the field is inaccessible by means of private access modifiers
      */
-    void update(I input);
+    default T getData(String fieldName) throws NoSuchFieldException, IllegalAccessException {
+        return (T) getClass().getDeclaredField(fieldName).get(this);
+    }
 
     /**
      * Retrieves the identifier (id) of this game component, the identifier is
@@ -109,19 +103,19 @@ public interface Component<I> {
         @Deprecated
         @Override
         public int intValue() {
-            throw new UnsupportedOperationException("Deprecated call, use `Component.Id#getId()`");
+            throw new UnsupportedOperationException("Deprecated call, use \"Component.Id#longValue()\"");
         }
 
         @Deprecated
         @Override
         public float floatValue() {
-            throw new UnsupportedOperationException("Deprecated call, use `Component.Id#getId()`");
+            throw new UnsupportedOperationException("Deprecated call, use \"Component.Id#longValue()\"");
         }
 
         @Deprecated
         @Override
         public double doubleValue() {
-            throw new UnsupportedOperationException("Deprecated call, use `Component.Id#getId()`");
+            throw new UnsupportedOperationException("Deprecated call, use \"Component.Id#longValue()\"");
         }
     }
 }

--- a/articular-es/src/main/java/articular/core/component/Component.java
+++ b/articular-es/src/main/java/articular/core/component/Component.java
@@ -38,11 +38,10 @@ import java.lang.reflect.Field;
 /**
  * A template representing a Game {@link Entity} housing data objects.
  *
- * @param <T> the type of the component object data in memory
  * @author pavl_g
  */
 @SuppressWarnings("unchecked")
-public interface Component<T> {
+public interface Component {
 
     /**
      * Retrieves all the declared fields in an array of {@link Field}.
@@ -56,12 +55,13 @@ public interface Component<T> {
     /**
      * Retrieves a data field by its name in a field pointer.
      *
+     * @param <T> the type of the component object data in memory
      * @param fieldName the field name in the component class
      * @return a reference object to the required field
      * @throws NoSuchFieldException if the submitted field is not found in this component
      * @throws IllegalAccessException if the field is inaccessible by means of private access modifiers
      */
-    default T getData(String fieldName) throws NoSuchFieldException, IllegalAccessException {
+    default <T> T getData(String fieldName) throws NoSuchFieldException, IllegalAccessException {
         return (T) getClass().getDeclaredField(fieldName).get(this);
     }
 

--- a/articular-es/src/main/java/articular/core/component/StandardGameComponent.java
+++ b/articular-es/src/main/java/articular/core/component/StandardGameComponent.java
@@ -1,0 +1,63 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2023, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.core.component;
+
+/**
+ * Provides a standard implementation to the game entity {@link Component},
+ * in which a component will have an identifier and should have immutable data.
+ *
+ * @param <T> a boundary type for the immutable data objects
+ * @author pavl_g
+ */
+public class StandardGameComponent<T> implements Component<T> {
+
+    /**
+     * The component identifier that maps this component
+     * to its game entity.
+     */
+    protected final Component.Id componentId;
+
+    /**
+     * Instantiates a new game entity component object.
+     *
+     * @param componentId the game component identifier to map this component
+     *                    to its game entity
+     */
+    public StandardGameComponent(Component.Id componentId) {
+        this.componentId = componentId;
+    }
+
+    @Override
+    public final Id getId() {
+        return componentId;
+    }
+}

--- a/articular-es/src/main/java/articular/core/component/StandardGameComponent.java
+++ b/articular-es/src/main/java/articular/core/component/StandardGameComponent.java
@@ -35,10 +35,9 @@ package articular.core.component;
  * Provides a standard implementation to the game entity {@link Component},
  * in which a component will have an identifier and should have immutable data.
  *
- * @param <T> a boundary type for the immutable data objects
  * @author pavl_g
  */
-public class StandardGameComponent<T> implements Component<T> {
+public class StandardGameComponent implements Component {
 
     /**
      * The component identifier that maps this component

--- a/articular-es/src/main/java/articular/core/component/UpdatableComponent.java
+++ b/articular-es/src/main/java/articular/core/component/UpdatableComponent.java
@@ -34,45 +34,28 @@ package articular.core.component;
 import articular.core.Entity;
 
 /**
- * Provides a base implementation to the game entity {@link Component},
- * in which each component will have a game entity instance and an identifier.
+ * A template representing a game updatable data component (mutable data component).
  *
- * @param <I> the input type to the game loop pattern
+ * @param <T> the type of the mutable component object
+ * @param <I> the input type of the update loop
  * @author pavl_g
  */
-public abstract class BaseGameComponent<I> implements Component<I> {
+public interface UpdatableComponent<T, I> extends Component<T> {
 
     /**
-     * The enclosing game entity that will update
-     * this component.
-     */
-    protected final Entity<I> entity;
-
-    /**
-     * The component identifier that maps this component
-     * to its game entity.
-     */
-    protected final Component.Id componentId;
-
-    /**
-     * Instantiates a new game entity component object.
+     * Updates this game component with an abstract input.
      *
-     * @param entity the entity enclosing this game component
-     * @param componentId the game component identifier to map this component
-     *                    to its game entity
+     * <p>
+     * Override this method and use the Game loop pattern to link the
+     * original game states to this component via the game {@link Entity}s.
+     * </p>
+     *
+     * <p>
+     * This method is dispatched by {@link articular.core.UpdatableEntity#update(I)} )},
+     * never call it manually!
+     * </p>
+     *
+     * @param input an input to perform the update on
      */
-    public BaseGameComponent(Entity<I> entity, Component.Id componentId) {
-        this.entity = entity;
-        this.componentId = componentId;
-    }
-
-    @Override
-    public Entity<I> getEntity() {
-        return entity;
-    }
-
-    @Override
-    public Id getId() {
-        return componentId;
-    }
+    void update(I input);
 }

--- a/articular-es/src/main/java/articular/core/component/UpdatableComponent.java
+++ b/articular-es/src/main/java/articular/core/component/UpdatableComponent.java
@@ -32,15 +32,15 @@
 package articular.core.component;
 
 import articular.core.Entity;
+import articular.util.UpdatableEntity;
 
 /**
  * A template representing a game updatable data component (mutable data component).
  *
- * @param <T> the type of the mutable component object
  * @param <I> the input type of the update loop
  * @author pavl_g
  */
-public interface UpdatableComponent<T, I> extends Component<T> {
+public interface UpdatableComponent<I> extends Component {
 
     /**
      * Updates this game component with an abstract input.
@@ -51,7 +51,7 @@ public interface UpdatableComponent<T, I> extends Component<T> {
      * </p>
      *
      * <p>
-     * This method is dispatched by {@link articular.core.UpdatableEntity#update(I)} )},
+     * This method is dispatched by {@link UpdatableEntity#update(I)} )},
      * never call it manually!
      * </p>
      *

--- a/articular-es/src/main/java/articular/core/package-info.java
+++ b/articular-es/src/main/java/articular/core/package-info.java
@@ -31,6 +31,6 @@
 
 /**
  * Provides the core Game Entity interface {@link articular.core.Entity}
- * and its base implementation {@link articular.core.BaseGameEntity}.
+ * and its base implementation {@link articular.util.StandardGameEntity}.
  */
 package articular.core;

--- a/articular-es/src/main/java/articular/util/ConcurrentEntityComponentManager.java
+++ b/articular-es/src/main/java/articular/util/ConcurrentEntityComponentManager.java
@@ -31,7 +31,6 @@
 
 package articular.util;
 
-import articular.core.Entity;
 import articular.core.component.Component;
 
 /**
@@ -39,10 +38,11 @@ import articular.core.component.Component;
  * synchronize structural changes (addition/removal) of the map {@link EntityComponentManager#getEntities()}
  * with the game loop update {@link EntityComponentManager#update(Object)}.
  *
+ * @param <T> the type of the game component data
  * @param <I> the input type to the game loop pattern
  * @author pavl_g
  */
-public class ConcurrentEntityComponentManager<I> extends EntityComponentManager<I> {
+public class ConcurrentEntityComponentManager<T, I> extends EntityComponentManager<T, I> {
 
     /**
      * Instantiates a thread-safe ECS manager.
@@ -52,22 +52,22 @@ public class ConcurrentEntityComponentManager<I> extends EntityComponentManager<
     }
 
     @Override
-    public synchronized void register(Entity<I> entity) {
+    public synchronized void register(StandardGameEntity<T> entity) {
         super.register(entity);
     }
 
     @Override
-    public synchronized void register(Entity<I> entity, Component<I> component) {
+    public synchronized void register(StandardGameEntity<T> entity, Component<T> component) {
         super.register(entity, component);
     }
 
     @Override
-    public synchronized void unregister(Entity<I> entity) {
+    public synchronized void unregister(StandardGameEntity<T> entity) {
         super.unregister(entity);
     }
 
     @Override
-    public synchronized void unregister(Entity<I> entity, Component<I> component) {
+    public synchronized void unregister(StandardGameEntity<T> entity, Component<T> component) {
         super.unregister(entity, component);
     }
 

--- a/articular-es/src/main/java/articular/util/ConcurrentEntityComponentManager.java
+++ b/articular-es/src/main/java/articular/util/ConcurrentEntityComponentManager.java
@@ -38,11 +38,10 @@ import articular.core.component.Component;
  * synchronize structural changes (addition/removal) of the map {@link EntityComponentManager#getEntities()}
  * with the game loop update {@link EntityComponentManager#update(Object)}.
  *
- * @param <T> the type of the game component data
  * @param <I> the input type to the game loop pattern
  * @author pavl_g
  */
-public class ConcurrentEntityComponentManager<T, I> extends EntityComponentManager<T, I> {
+public class ConcurrentEntityComponentManager<I> extends EntityComponentManager<I> {
 
     /**
      * Instantiates a thread-safe ECS manager.
@@ -52,22 +51,22 @@ public class ConcurrentEntityComponentManager<T, I> extends EntityComponentManag
     }
 
     @Override
-    public synchronized void register(StandardGameEntity<T> entity) {
+    public synchronized void register(StandardGameEntity entity) {
         super.register(entity);
     }
 
     @Override
-    public synchronized void register(StandardGameEntity<T> entity, Component<T> component) {
+    public synchronized void register(StandardGameEntity entity, Component component) {
         super.register(entity, component);
     }
 
     @Override
-    public synchronized void unregister(StandardGameEntity<T> entity) {
+    public synchronized void unregister(StandardGameEntity entity) {
         super.unregister(entity);
     }
 
     @Override
-    public synchronized void unregister(StandardGameEntity<T> entity, Component<T> component) {
+    public synchronized void unregister(StandardGameEntity entity, Component component) {
         super.unregister(entity, component);
     }
 

--- a/articular-es/src/main/java/articular/util/EntityComponentManager.java
+++ b/articular-es/src/main/java/articular/util/EntityComponentManager.java
@@ -32,7 +32,9 @@
 package articular.util;
 
 import articular.core.Entity;
+import articular.core.UpdatableEntity;
 import articular.core.component.Component;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,15 +55,16 @@ import java.util.Map;
  * to the game loop.
  * </p>
  *
- * @param <I> the input type to the game loop pattern
+ * @param <T> the type of the game component data
+ * @param <I> the type of the input to the game loop
  * @author pavl_g
  */
-public class EntityComponentManager<I> {
+public class EntityComponentManager<T, I> {
 
     /**
      * The proposed Game entities
      */
-    protected Map<String, Entity<I>> entities;
+    protected Map<? super Number, Entity<T>> entities;
 
     /**
      * Instantiates an articulation manager object by
@@ -76,8 +79,8 @@ public class EntityComponentManager<I> {
      *
      * @param entity a game entity instance to register
      */
-    public void register(Entity<I> entity) {
-        entities.put(entity.getName(), entity);
+    public void register(StandardGameEntity<T> entity) {
+        entities.put(entity.getId().longValue(), entity);
     }
 
     /**
@@ -85,8 +88,8 @@ public class EntityComponentManager<I> {
      *
      * @param entity a game entity instance to unregister
      */
-    public void unregister(Entity<I> entity) {
-        entities.remove(entity.getName(), entity);
+    public void unregister(StandardGameEntity<T> entity) {
+        entities.remove(entity.getId().longValue(), entity);
     }
 
     /**
@@ -95,8 +98,8 @@ public class EntityComponentManager<I> {
      * @param entity the game entity instance
      * @param component the component instance to register to this game entity
      */
-    public void register(Entity<I> entity, Component<I> component) {
-        entity.getComponents().put(component.getId().longValue(), component);
+    public void register(StandardGameEntity<T> entity, Component<T> component) {
+        entity.getComponentsMap().put(component.getId().longValue(), component);
     }
 
     /**
@@ -105,8 +108,8 @@ public class EntityComponentManager<I> {
      * @param entity the game entity instance
      * @param component the component instance to be unregistered from this game entity
      */
-    public void unregister(Entity<I> entity, Component<I> component) {
-        entity.getComponents().remove(component.getId().longValue());
+    public void unregister(StandardGameEntity<T> entity, Component<T> component) {
+        entity.getComponentsMap().remove(component.getId().longValue());
     }
 
     /**
@@ -115,15 +118,19 @@ public class EntityComponentManager<I> {
      * @param input the game loop input value
      */
     public void update(I input) {
-        entities.forEach((key, entity) -> entity.update(input));
+        entities.forEach((key, entity) -> {
+            if (entity instanceof UpdatableEntity) {
+                ((UpdatableEntity<T, I>) entity).update(input);
+            }
+        });
     }
 
     /**
      * Retrieves the registered game entities.
      *
-     * @return a map of the registered game entities
+     * @return a collection of the registered game entities
      */
-    public Map<String, Entity<I>> getEntities() {
-        return entities;
+    public Collection<Entity<T>> getEntities() {
+        return entities.values();
     }
 }

--- a/articular-es/src/main/java/articular/util/EntityComponentManager.java
+++ b/articular-es/src/main/java/articular/util/EntityComponentManager.java
@@ -32,7 +32,6 @@
 package articular.util;
 
 import articular.core.Entity;
-import articular.core.UpdatableEntity;
 import articular.core.component.Component;
 import java.util.Collection;
 import java.util.HashMap;
@@ -55,16 +54,15 @@ import java.util.Map;
  * to the game loop.
  * </p>
  *
- * @param <T> the type of the game component data
  * @param <I> the type of the input to the game loop
  * @author pavl_g
  */
-public class EntityComponentManager<T, I> {
+public class EntityComponentManager<I> {
 
     /**
      * The proposed Game entities
      */
-    protected Map<? super Number, Entity<T>> entities;
+    protected Map<? super Number, Entity> entities;
 
     /**
      * Instantiates an articulation manager object by
@@ -79,7 +77,7 @@ public class EntityComponentManager<T, I> {
      *
      * @param entity a game entity instance to register
      */
-    public void register(StandardGameEntity<T> entity) {
+    public void register(StandardGameEntity entity) {
         entities.put(entity.getId().longValue(), entity);
     }
 
@@ -88,7 +86,7 @@ public class EntityComponentManager<T, I> {
      *
      * @param entity a game entity instance to unregister
      */
-    public void unregister(StandardGameEntity<T> entity) {
+    public void unregister(StandardGameEntity entity) {
         entities.remove(entity.getId().longValue(), entity);
     }
 
@@ -98,7 +96,7 @@ public class EntityComponentManager<T, I> {
      * @param entity the game entity instance
      * @param component the component instance to register to this game entity
      */
-    public void register(StandardGameEntity<T> entity, Component<T> component) {
+    public void register(StandardGameEntity entity, Component component) {
         entity.getComponentsMap().put(component.getId().longValue(), component);
     }
 
@@ -108,7 +106,7 @@ public class EntityComponentManager<T, I> {
      * @param entity the game entity instance
      * @param component the component instance to be unregistered from this game entity
      */
-    public void unregister(StandardGameEntity<T> entity, Component<T> component) {
+    public void unregister(StandardGameEntity entity, Component component) {
         entity.getComponentsMap().remove(component.getId().longValue());
     }
 
@@ -117,10 +115,11 @@ public class EntityComponentManager<T, I> {
      *
      * @param input the game loop input value
      */
+    @SuppressWarnings("unchecked")
     public void update(I input) {
         entities.forEach((key, entity) -> {
             if (entity instanceof UpdatableEntity) {
-                ((UpdatableEntity<T, I>) entity).update(input);
+                ((UpdatableEntity<I>) entity).update(input);
             }
         });
     }
@@ -130,7 +129,7 @@ public class EntityComponentManager<T, I> {
      *
      * @return a collection of the registered game entities
      */
-    public Collection<Entity<T>> getEntities() {
+    public Collection<Entity> getEntities() {
         return entities.values();
     }
 }

--- a/articular-es/src/main/java/articular/util/StandardGameEntity.java
+++ b/articular-es/src/main/java/articular/util/StandardGameEntity.java
@@ -33,30 +33,37 @@ package articular.util;
 
 import articular.core.Entity;
 import articular.core.component.Component;
-import articular.util.EntityComponentManager;
-
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Defines a base implementation for the {@link Entity}, the container
+ * Defines a standard base implementation for the {@link Entity}, the container
  * object of the articular-es API.
  *
- * @param <T> the type of the game component object
+ * @param <T> the type of the game components' data
  * @author pavl_g
  */
-public abstract class BaseGameEntity<T> implements Entity<T> {
+public abstract class StandardGameEntity<T> implements Entity<T> {
 
     /**
-     * The name for this entity utilized by the
-     * {@link EntityComponentManager}.
+     * The name for this entity (nullable).
      */
     protected String name;
 
     /**
-     * A map for the Game entity components registered to this entity.
+     * A map for the game components registered to this entity.
      */
     protected final Map<? super Number, Component<T>> components;
+
+    /**
+     * Instantiates a default game entity with a {@link HashMap}.
+     *
+     * @param name the name of this game entity (nullable)
+     */
+    public StandardGameEntity(String name) {
+        this(name, new HashMap<>());
+    }
 
     /**
      * Instantiates a game entity with a name and game entity components.
@@ -66,10 +73,10 @@ public abstract class BaseGameEntity<T> implements Entity<T> {
      * provide a call to this constructor or an acceptable alternative.
      * </p>
      *
-     * @param name the name of this game entity
-     * @param components a map of game entity components
+     * @param name the name of this game entity (nullable)
+     * @param components a map of game entity components (nullable)
      */
-    public BaseGameEntity(String name, Map<? super Number, Component<T>> components) {
+    public StandardGameEntity(String name, Map<? super Number, Component<T>> components) {
         this.name = name;
         this.components = components;
     }
@@ -85,15 +92,23 @@ public abstract class BaseGameEntity<T> implements Entity<T> {
     }
 
     /**
-     * Retrieves a specific game entity component by its identifier.
+     * Retrieves a specific an entity component by its identifier.
      *
      * @param id the game entity component identifier
      * @return a game entity component or null if it doesn't exist (nullable)
      */
-    Component<T> getComponent(Component.Id id) {
+    @Override
+    public Component<T> getComponent(Component.Id id) {
         return components.get(id);
     }
 
+    /**
+     * Retrieves components of this entity mapped by their identifiers.
+     *
+     * @see StandardGameEntity#getComponent(Id)
+     * @see StandardGameEntity#getComponents()
+     * @return a map of game components registered to this entity
+     */
     protected Map<? super Number, Component<T>> getComponentsMap() {
         return components;
     }

--- a/articular-es/src/main/java/articular/util/StandardGameEntity.java
+++ b/articular-es/src/main/java/articular/util/StandardGameEntity.java
@@ -1,0 +1,100 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2023, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.util;
+
+import articular.core.Entity;
+import articular.core.component.Component;
+import articular.util.EntityComponentManager;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Defines a base implementation for the {@link Entity}, the container
+ * object of the articular-es API.
+ *
+ * @param <T> the type of the game component object
+ * @author pavl_g
+ */
+public abstract class BaseGameEntity<T> implements Entity<T> {
+
+    /**
+     * The name for this entity utilized by the
+     * {@link EntityComponentManager}.
+     */
+    protected String name;
+
+    /**
+     * A map for the Game entity components registered to this entity.
+     */
+    protected final Map<? super Number, Component<T>> components;
+
+    /**
+     * Instantiates a game entity with a name and game entity components.
+     *
+     * <p>
+     * Subclasses overriding the default constructor should
+     * provide a call to this constructor or an acceptable alternative.
+     * </p>
+     *
+     * @param name the name of this game entity
+     * @param components a map of game entity components
+     */
+    public BaseGameEntity(String name, Map<? super Number, Component<T>> components) {
+        this.name = name;
+        this.components = components;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Collection<Component<T>> getComponents() {
+        return components.values();
+    }
+
+    /**
+     * Retrieves a specific game entity component by its identifier.
+     *
+     * @param id the game entity component identifier
+     * @return a game entity component or null if it doesn't exist (nullable)
+     */
+    Component<T> getComponent(Component.Id id) {
+        return components.get(id);
+    }
+
+    protected Map<? super Number, Component<T>> getComponentsMap() {
+        return components;
+    }
+}

--- a/articular-es/src/main/java/articular/util/StandardGameEntity.java
+++ b/articular-es/src/main/java/articular/util/StandardGameEntity.java
@@ -41,10 +41,9 @@ import java.util.Map;
  * Defines a standard base implementation for the {@link Entity}, the container
  * object of the articular-es API.
  *
- * @param <T> the type of the game components' data
  * @author pavl_g
  */
-public abstract class StandardGameEntity<T> implements Entity<T> {
+public abstract class StandardGameEntity implements Entity {
 
     /**
      * The name for this entity (nullable).
@@ -54,7 +53,7 @@ public abstract class StandardGameEntity<T> implements Entity<T> {
     /**
      * A map for the game components registered to this entity.
      */
-    protected final Map<? super Number, Component<T>> components;
+    protected final Map<? super Number, Component> components;
 
     /**
      * Instantiates a default game entity with a {@link HashMap}.
@@ -76,7 +75,7 @@ public abstract class StandardGameEntity<T> implements Entity<T> {
      * @param name the name of this game entity (nullable)
      * @param components a map of game entity components (nullable)
      */
-    public StandardGameEntity(String name, Map<? super Number, Component<T>> components) {
+    public StandardGameEntity(String name, Map<? super Number, Component> components) {
         this.name = name;
         this.components = components;
     }
@@ -87,7 +86,7 @@ public abstract class StandardGameEntity<T> implements Entity<T> {
     }
 
     @Override
-    public Collection<Component<T>> getComponents() {
+    public Collection<Component> getComponents() {
         return components.values();
     }
 
@@ -98,7 +97,7 @@ public abstract class StandardGameEntity<T> implements Entity<T> {
      * @return a game entity component or null if it doesn't exist (nullable)
      */
     @Override
-    public Component<T> getComponent(Component.Id id) {
+    public Component getComponent(Component.Id id) {
         return components.get(id);
     }
 
@@ -109,7 +108,7 @@ public abstract class StandardGameEntity<T> implements Entity<T> {
      * @see StandardGameEntity#getComponents()
      * @return a map of game components registered to this entity
      */
-    protected Map<? super Number, Component<T>> getComponentsMap() {
+    protected Map<? super Number, Component> getComponentsMap() {
         return components;
     }
 }

--- a/articular-es/src/main/java/articular/util/UpdatableEntity.java
+++ b/articular-es/src/main/java/articular/util/UpdatableEntity.java
@@ -31,25 +31,37 @@
 
 package articular.core;
 
+import articular.core.component.Component;
 import articular.core.component.UpdatableComponent;
+import articular.util.StandardGameEntity;
+
+import java.util.Map;
 
 /**
  * Provides an update logic for the game entity.
  *
- * @param <T> the type of game components' data
  * @param <I> the type of the input to the game loop (used by the update method)
  */
-public interface UpdatableEntity<T, I> extends Entity<T> {
+public abstract class UpdatableEntity<I> extends StandardGameEntity {
+
+    public UpdatableEntity(String name) {
+        super(name);
+    }
+
+    public UpdatableEntity(String name, Map<? super Number, Component> components) {
+        super(name, components);
+    }
 
     /**
      * Updates this game entity through updating its components.
      *
      * @param input the input to the game loop pattern
      */
+    @SuppressWarnings("unchecked")
     default void update(I input) {
         getComponents().forEach((component) -> {
             if (component instanceof UpdatableComponent) {
-                ((UpdatableComponent<T, I>) component).update(input);
+                ((UpdatableComponent<I>) component).update(input);
             }
         });
     }

--- a/articular-es/src/main/java/articular/util/UpdatableEntity.java
+++ b/articular-es/src/main/java/articular/util/UpdatableEntity.java
@@ -29,18 +29,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.core;
+package articular.util;
 
 import articular.core.component.Component;
 import articular.core.component.UpdatableComponent;
-import articular.util.StandardGameEntity;
-
 import java.util.Map;
 
 /**
  * Provides an update logic for the game entity.
  *
  * @param <I> the type of the input to the game loop (used by the update method)
+ * @author pavl_g
  */
 public abstract class UpdatableEntity<I> extends StandardGameEntity {
 
@@ -58,7 +57,7 @@ public abstract class UpdatableEntity<I> extends StandardGameEntity {
      * @param input the input to the game loop pattern
      */
     @SuppressWarnings("unchecked")
-    default void update(I input) {
+    public void update(I input) {
         getComponents().forEach((component) -> {
             if (component instanceof UpdatableComponent) {
                 ((UpdatableComponent<I>) component).update(input);

--- a/articular-monkey/src/main/java/articular/jme/GameEntityManager.java
+++ b/articular-monkey/src/main/java/articular/jme/GameEntityManager.java
@@ -48,7 +48,7 @@ public class GameEntityManager<T> extends BaseAppState {
     /**
      * The ECS manager controlling the game entities and their components.
      */
-    protected EntityComponentManager<T, Float> entityComponentManager;
+    protected EntityComponentManager<Float> entityComponentManager;
 
     /**
      * Instantiates a game entity manager with a {@link ConcurrentEntityComponentManager} as a default
@@ -63,7 +63,7 @@ public class GameEntityManager<T> extends BaseAppState {
      *
      * @param entityComponentManager a user-defined implementation for the entityComponentManager
      */
-    public GameEntityManager(EntityComponentManager<T, Float> entityComponentManager) {
+    public GameEntityManager(EntityComponentManager<Float> entityComponentManager) {
         this.entityComponentManager = entityComponentManager;
     }
 
@@ -104,7 +104,7 @@ public class GameEntityManager<T> extends BaseAppState {
      *
      * @return the game entity-component manager for this state
      */
-    public EntityComponentManager<T, Float> getEntityComponentManager() {
+    public EntityComponentManager<Float> getEntityComponentManager() {
         return entityComponentManager;
     }
 }

--- a/articular-monkey/src/main/java/articular/jme/GameEntityManager.java
+++ b/articular-monkey/src/main/java/articular/jme/GameEntityManager.java
@@ -40,15 +40,32 @@ import com.jme3.app.state.BaseAppState;
  * Binds the {@link EntityComponentManager} to a jMonkeyEngine {@link BaseAppState}
  * in a game environment.
  *
+ * @param <T> the type of the game components' data
  * @author pavl_g
  */
-public class GameEntityManager extends BaseAppState {
+public class GameEntityManager<T> extends BaseAppState {
 
     /**
      * The ECS manager controlling the game entities and their components.
      */
-    protected EntityComponentManager<Float> entityComponentManager =
-                                                new ConcurrentEntityComponentManager<>();
+    protected EntityComponentManager<T, Float> entityComponentManager;
+
+    /**
+     * Instantiates a game entity manager with a {@link ConcurrentEntityComponentManager} as a default
+     * implementation.
+     */
+    public GameEntityManager() {
+        this(new ConcurrentEntityComponentManager<>());
+    }
+
+    /**
+     * Instantiates a game entity manager with a user-defined implementation.
+     *
+     * @param entityComponentManager a user-defined implementation for the entityComponentManager
+     */
+    public GameEntityManager(EntityComponentManager<T, Float> entityComponentManager) {
+        this.entityComponentManager = entityComponentManager;
+    }
 
     @Override
     protected void initialize(Application app) {
@@ -87,7 +104,7 @@ public class GameEntityManager extends BaseAppState {
      *
      * @return the game entity-component manager for this state
      */
-    public EntityComponentManager<Float> getEntityComponentManager() {
+    public EntityComponentManager<T, Float> getEntityComponentManager() {
         return entityComponentManager;
     }
 }


### PR DESCRIPTION
This PR hopefully corrects the design error, by reintroducing the Game Entity Component as a data structure (of immutable/mutable data) as a fundamental part of the ECS architecture.