### PR TITLE
Jme example: added TestArticularJme

### DIFF
--- a/articular-es/src/main/java/articular/core/component/Module.java
+++ b/articular-es/src/main/java/articular/core/component/Module.java
@@ -1,7 +1,7 @@
 /*
  * BSD 3-Clause License
  *
- * Copyright (c) 2023, Articular-ES, The AvrSandbox Project
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -43,12 +43,28 @@ public interface Module extends Component {
     default void register(Component component) {
         getComponents().put(component.getId().intValue(), component);
     }
+    default void register(Component.Id id, Component component) {
+        getComponents().put(id.intValue(), component);
+    }
     default void unregister(Component component) {
         getComponents().remove(component.getId().intValue());
     }
 
-    default boolean hasComponent(Component component) {
-        return getComponents().get(component.getId().intValue()) != null;
+    default void unregister(Component.Id id) {
+        getComponents().remove(id.intValue());
     }
+
+    default boolean hasComponent(Component.Id id) {
+        return getComponent(id) != null;
+    }
+
+    default boolean hasComponent(Component component) {
+        return getComponent(component.getId()) != null;
+    }
+
+    default Component getComponent(Component.Id id) {
+        return getComponents().get(id.intValue());
+    }
+
     MemoryMap.EntityComponentMap getComponents();
 }

--- a/articular-examples/build.gradle
+++ b/articular-examples/build.gradle
@@ -22,4 +22,9 @@ repositories {
 
 dependencies {
     implementation project(path: ':articular-es')
+    implementation "org.jmonkeyengine:jme3-core:3.6.1-stable"
+    implementation "org.jmonkeyengine:jme3-desktop:3.6.1-stable"
+    implementation "org.jmonkeyengine:jme3-lwjgl3:3.6.1-stable"
+    implementation "org.jmonkeyengine:jme3-effects:3.6.1-stable"
+    implementation "org.jmonkeyengine:jme3-testdata:3.6.1-stable"
 }

--- a/articular-examples/src/main/java/articular/example/labs/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/package-info.java
@@ -1,0 +1,1 @@
+package articular.example.labs;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/TestArticularJme.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/TestArticularJme.java
@@ -1,0 +1,116 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme;
+
+import articular.core.component.Component;
+import articular.example.labs.techdemos.jme.components.*;
+import articular.example.labs.techdemos.jme.systems.JumpKickCinematicBuilder;
+import articular.example.labs.techdemos.jme.systems.JaimeBuilder;
+import articular.example.labs.techdemos.jme.systems.KeyInputSystem;
+import articular.util.ArticularManager;
+import com.jme3.app.*;
+import com.jme3.input.KeyInput;
+import com.jme3.input.controls.KeyTrigger;
+import com.jme3.math.Vector3f;
+import com.jme3.system.AppSettings;
+
+/**
+ * Refactored TestJaime to ECS architecture.
+ *
+ * @author Nehon
+ * @author pavl_g
+ */
+public class TestArticularJme extends SimpleApplication {
+
+    private final ArticularManager<SimpleApplication> ecsManager = new ArticularManager<>();
+    private final JaimeBuilder jaimeBuilder = new JaimeBuilder();
+    private final JumpKickCinematicBuilder jumpKickCinematicBuilder = new JumpKickCinematicBuilder();
+    private final KeyInputSystem keyInputSystem = new KeyInputSystem();
+    private final ComponentCollection characters =
+            new ComponentCollection(GameComponents.JAIME.getEntity().getId());
+    private final ComponentCollection cinematics =
+            new ComponentCollection(GameComponents.CINEMATIC_COMPONENTS.getEntity().getId());
+
+    private final ComponentCollection inputs =
+            new ComponentCollection(GameComponents.INPUT_COMPONENTS.getEntity().getId());
+
+    public static void main(String... argv){
+        TestArticularJme app = new TestArticularJme();
+        final AppSettings settings = new AppSettings(true);
+        settings.setResizable(true);
+        app.setSettings(settings);
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+
+        // environment setup and update
+        final Component jaime0 = new Jaime(getAssetManager(), new Vector3f(0, 0f, 0)); // initialize components
+        final Component jaime1 = new Jaime(getAssetManager(), new Vector3f(2f, 0f, 0f)); // initialize components
+        final Component jaime2 = new Jaime(getAssetManager(), new Vector3f(0f, 0f, 2f)); // initialize components
+        final Component jaime3 = new Jaime(getAssetManager(), new Vector3f(2f, 0f, 2f)); // initialize components
+        final Component jaime4 = new Jaime(getAssetManager(), new Vector3f(4f, 0f, 0f)); // initialize components
+
+        ecsManager.allocateMemoryMap(jaimeBuilder); // allocate a system and register it
+        characters.register(jaime0);
+        characters.register(jaime1);
+        characters.register(jaime2);
+        characters.register(jaime3);
+        characters.register(jaime4);
+        ecsManager.register(GameComponents.JAIME.getEntity(), characters, jaimeBuilder);
+        ecsManager.updateSystemComponents(jaimeBuilder, this); // update environment components
+
+        final Component cinematicComponent0 = new JumpKickCinematic(rootNode, 30);
+        final Component cinematicComponent1 = new JumpKickCinematic(rootNode, 30);
+        final Component cinematicComponent2 = new JumpKickCinematic(rootNode, 30);
+        final Component cinematicComponent3 = new JumpKickCinematic(rootNode, 30);
+
+        ecsManager.allocateMemoryMap(jumpKickCinematicBuilder);
+        cinematics.register(jaime0.getId(), cinematicComponent0);
+        cinematics.register(jaime1.getId(), cinematicComponent1);
+        cinematics.register(jaime2.getId(), cinematicComponent2);
+        cinematics.register(jaime3.getId(), cinematicComponent3);
+
+        ecsManager.register(GameComponents.CINEMATIC_COMPONENTS.getEntity(), cinematics, jumpKickCinematicBuilder);
+        ecsManager.updateSystemComponents(jumpKickCinematicBuilder, this);
+
+        final Component playInput = new InputComponent("start", new KeyTrigger(KeyInput.KEY_P));
+        final Component exitInput = new InputComponent("exit", new KeyTrigger(KeyInput.KEY_E));
+
+        ecsManager.allocateMemoryMap(keyInputSystem);
+        inputs.register(playInput);
+        inputs.register(exitInput);
+        ecsManager.register(GameComponents.INPUT_COMPONENTS.getEntity(), inputs, keyInputSystem);
+        ecsManager.updateSystemComponents(keyInputSystem, this);
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/ComponentCollection.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/ComponentCollection.java
@@ -1,0 +1,56 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.components;
+
+import articular.core.MemoryMap;
+import articular.core.component.Component;
+import articular.core.component.Module;
+
+public class ComponentCollection implements Module {
+
+    private final MemoryMap.EntityComponentMap ecsMap = new MemoryMap.EntityComponentMap();
+    private final Component.Id componentId;
+
+    public ComponentCollection(Component.Id componentId) {
+        this.componentId = componentId;
+    }
+
+    @Override
+    public Id getId() {
+        return componentId;
+    }
+
+    @Override
+    public MemoryMap.EntityComponentMap getComponents() {
+        return ecsMap;
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/GameComponents.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/GameComponents.java
@@ -1,0 +1,50 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.components;
+
+import articular.core.Entity;
+
+public enum GameComponents {
+    JAIME(Jaime.class.getName()),
+    CINEMATIC_COMPONENTS(JumpKickCinematic.class.getName()),
+    INPUT_COMPONENTS(InputComponent.class.getName());
+
+    private final String entity;
+
+    GameComponents(String entity) {
+        this.entity = entity;
+    }
+
+    public Entity getEntity() {
+        return new Entity(entity);
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/InputComponent.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/InputComponent.java
@@ -1,0 +1,52 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.components;
+
+import articular.core.component.Component;
+import com.jme3.input.controls.KeyTrigger;
+
+public final class InputComponent implements Component {
+
+    private final String mapping;
+    private final KeyTrigger key;
+
+    public InputComponent(String mapping, KeyTrigger key) {
+        this.mapping = mapping;
+        this.key = key;
+    }
+
+    @Override
+    public Id getId() {
+        return new Component.Id((hashCode() >>> 16) ^
+                GameComponents.INPUT_COMPONENTS.getEntity().getId().intValue());
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/Jaime.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/Jaime.java
@@ -1,0 +1,64 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.components;
+
+import articular.core.component.Component;
+import com.jme3.asset.AssetManager;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.PointLight;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Node;
+
+/**
+ * A composite component providing high-level object fields
+ * for the scene environment, this corresponds to the setupScene().
+ *
+ * @author pavl_g
+ */
+public final class Jaime implements Component {
+
+    private final Node jaime;
+    private final Vector3f worldPosition;
+    private final AmbientLight ambientLight = new AmbientLight();
+    private final PointLight pointLight = new PointLight();
+
+    public Jaime(final AssetManager assetManager, final Vector3f worldPosition) {
+        jaime = (Node) assetManager.loadModel("Models/Jaime/Jaime.j3o");
+        this.worldPosition = worldPosition;
+    }
+
+    @Override
+    public Id getId() {
+        return new Component.Id((hashCode() >>> 16) ^
+                GameComponents.JAIME.getEntity().getId().intValue());
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/JumpKickCinematic.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/JumpKickCinematic.java
@@ -1,0 +1,71 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.components;
+
+import articular.core.component.Component;
+import com.jme3.anim.AnimFactory;
+import com.jme3.animation.LoopMode;
+import com.jme3.cinematic.Cinematic;
+import com.jme3.cinematic.MotionPath;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Node;
+
+public class JumpKickCinematic implements Component {
+
+    private final Cinematic cinematic;
+    private final AnimFactory jumpForward = new AnimFactory(1f, "JumpForward", 30f);
+    private final AnimFactory startingPosition = new AnimFactory(0.01f, "StartingPosition", 30f);
+    private final MotionPath motionPath = new MotionPath();
+
+    public JumpKickCinematic(final Node scene, final float initialDuration) {
+        cinematic = new Cinematic(scene, initialDuration);
+
+        jumpForward.addTimeTranslation(0, new Vector3f(0, 0, -3));
+        jumpForward.addTimeTranslation(0.35f, new Vector3f(0, 1, -1.5f));
+        jumpForward.addTimeTranslation(0.7f, new Vector3f(0, 0, 0));
+
+        motionPath.addWayPoint(new Vector3f(1.1f, 1.2f, 2.9f));
+        motionPath.addWayPoint(new Vector3f(0f, 1.2f, 3.0f));
+        motionPath.addWayPoint(new Vector3f(-1.1f, 1.2f, 2.9f));
+        // motionPath.enableDebugShape(app.getAssetManager(), app.getRootNode());
+        motionPath.setCurveTension(0.8f);
+
+        cinematic.setSpeed(1.2f);
+        cinematic.setLoopMode(LoopMode.Loop);
+    }
+
+    @Override
+    public Id getId() {
+        return new Component.Id((hashCode() >>> 16) ^
+                GameComponents.CINEMATIC_COMPONENTS.getEntity().getId().intValue());
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/components/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.components;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JaimeBuilder.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JaimeBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.systems;
+
+import articular.core.MemoryMap;
+import articular.core.component.Component;
+import articular.core.component.Module;
+import articular.core.system.ArticularSystem;
+import articular.core.system.SystemEntitiesUpdater;
+import articular.core.system.manager.EntityComponentManager;
+import articular.example.labs.techdemos.jme.components.GameComponents;
+import com.jme3.anim.util.AnimMigrationUtils;
+import com.jme3.app.SimpleApplication;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.PointLight;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector3f;
+import com.jme3.renderer.queue.RenderQueue;
+import com.jme3.scene.Node;
+
+/**
+ * A system used for building Jaime characters at runtime.
+ *
+ * @author pavl_g
+ */
+public class JaimeBuilder implements SystemEntitiesUpdater<SimpleApplication> {
+
+    @Override
+    public ArticularSystem getAssociatedSystem() {
+        return Systems.ENV_SYSTEM;
+    }
+
+    @Override
+    public void update(MemoryMap.EntityComponentMap entityMap, EntityComponentManager<SimpleApplication> entityComponentManager, SimpleApplication input) {
+        final Module env = (Module)
+                entityComponentManager.getComponent(GameComponents.JAIME.getEntity(), this);
+        env.getComponents().forEach((number, component) -> {
+            try {
+                setup(input, component);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void setup(SimpleApplication app, Component env) throws NoSuchFieldException, IllegalAccessException {
+        // Get involved components
+        final Vector3f worldPosition = env.getData("worldPosition");
+        final Node jaime = env.getData("jaime");
+        final AmbientLight al = env.getData("ambientLight");
+        final PointLight pl = env.getData("pointLight");
+
+        final Vector3f max3f = new Vector3f(Math.max(1, worldPosition.getX()),
+                Math.max(1, worldPosition.getY()), Math.max(1, worldPosition.getZ()));
+
+        // perform operational code on them
+        final Node environment = new Node();
+        environment.setLocalTranslation(worldPosition);
+
+        AnimMigrationUtils.migrate(jaime);
+        jaime.setShadowMode(RenderQueue.ShadowMode.CastAndReceive);
+        environment.attachChild(jaime);
+
+        al.setColor(new ColorRGBA(0.1f, 0.1f, 0.1f, 1));
+        environment.addLight(al);
+
+        //pointlight to fake indirect light coming from the ground
+        pl.setColor(ColorRGBA.White.mult(1.5f));
+        pl.setPosition(new Vector3f(0, 0, 1).add(max3f));
+        pl.setRadius(5);
+        environment.addLight(pl);
+
+        app.getRootNode().attachChild(environment);
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JumpKickCinematicBuilder.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JumpKickCinematicBuilder.java
@@ -1,0 +1,143 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.systems;
+
+import articular.core.MemoryMap;
+import articular.core.component.Component;
+import articular.core.component.Module;
+import articular.core.system.ArticularSystem;
+import articular.core.system.SystemEntitiesUpdater;
+import articular.core.system.manager.EntityComponentManager;
+import articular.example.labs.techdemos.jme.components.GameComponents;
+import com.jme3.anim.AnimClip;
+import com.jme3.anim.AnimComposer;
+import com.jme3.anim.AnimFactory;
+import com.jme3.app.SimpleApplication;
+import com.jme3.cinematic.Cinematic;
+import com.jme3.cinematic.events.AnimEvent;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Node;
+
+/**
+ * A system for executing jump-kick-wave cinematic
+ * on jaime characters.
+ *
+ * @author pavl_g
+ */
+public class JumpKickCinematicBuilder implements SystemEntitiesUpdater<SimpleApplication> {
+
+    @Override
+    public ArticularSystem getAssociatedSystem() {
+        return Systems.CINEMATIC_SYSTEM;
+    }
+
+    @Override
+    public void update(MemoryMap.EntityComponentMap entityMap, EntityComponentManager<SimpleApplication> entityComponentManager, SimpleApplication input) {
+        final Module cinematics =
+                (Module) entityComponentManager.getComponent(GameComponents.CINEMATIC_COMPONENTS.getEntity(), this);
+        try {
+            setup(input, entityComponentManager, cinematics);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setup(SimpleApplication app, EntityComponentManager<SimpleApplication> ecsManager, Module module)
+            throws NoSuchFieldException, IllegalAccessException {
+
+        // attach cinematic objects to their jaime
+        final MemoryMap.EntityComponentMap map = ecsManager.getPrimaryMemoryMap().get(Systems.ENV_SYSTEM.getSystemName());
+        final Module jaimes = (Module) map.get(GameComponents.JAIME.getEntity().getId().intValue());
+        jaimes.getComponents().forEach((id, jaimeComponent) -> {
+            try {
+
+                if (!module.hasComponent(jaimeComponent.getId())) {
+                    return;
+                }
+
+                final Component component = module.getComponents().get(id);
+
+                final Cinematic cinematic = component.getData("cinematic");
+                final AnimFactory jumpForward = component.getData("jumpForward");
+                final AnimFactory startingPosition = component.getData("startingPosition");
+
+                final Node jaime = jaimeComponent.getData("jaime");
+                app.getStateManager().attach(cinematic);
+
+                final AnimClip forwardClip = jumpForward.buildAnimation(jaime);
+                final AnimComposer composer = jaime.getControl(AnimComposer.class);
+
+                composer.addAnimClip(forwardClip);
+                /*
+                 * Add a clip that warps the model to its starting position.
+                 */
+                startingPosition.addTimeTranslation(0f, new Vector3f(0f, 0f, -3f));
+
+                final AnimClip startClip = startingPosition.buildAnimation(jaime);
+                composer.addAnimClip(startClip);
+
+                composer.makeLayer("SpatialLayer", null);
+                String boneLayer = AnimComposer.DEFAULT_LAYER;
+
+                cinematic.addCinematicEvent(0f,
+                        new AnimEvent(composer, "StartingPosition", "SpatialLayer"));
+                cinematic.enqueueCinematicEvent(
+                        new AnimEvent(composer, "Idle", boneLayer));
+
+                final float jumpStart = cinematic.enqueueCinematicEvent(
+                        new AnimEvent(composer, "JumpStart", boneLayer));
+                cinematic.addCinematicEvent(jumpStart + 0.2f,
+                        new AnimEvent(composer, "JumpForward", "SpatialLayer"));
+                cinematic.enqueueCinematicEvent(
+                        new AnimEvent(composer, "JumpEnd", boneLayer));
+                cinematic.enqueueCinematicEvent(
+                        new AnimEvent(composer, "Punches", boneLayer));
+                cinematic.enqueueCinematicEvent(
+                        new AnimEvent(composer, "SideKick", boneLayer));
+
+                final AnimEvent idleOneSecond = new AnimEvent(composer, "Idle", boneLayer);
+                idleOneSecond.setInitialDuration(1f);
+
+                cinematic.enqueueCinematicEvent(idleOneSecond);
+                cinematic.enqueueCinematicEvent(
+                        new AnimEvent(composer, "Wave", boneLayer));
+                cinematic.enqueueCinematicEvent(
+                        new AnimEvent(composer, "Idle", boneLayer));
+
+                cinematic.fitDuration();
+                cinematic.play();
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/KeyInputSystem.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/KeyInputSystem.java
@@ -1,0 +1,102 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.systems;
+
+import articular.core.MemoryMap;
+import articular.core.component.Module;
+import articular.core.system.ArticularSystem;
+import articular.core.system.SystemEntitiesUpdater;
+import articular.core.system.manager.EntityComponentManager;
+import articular.example.labs.techdemos.jme.components.GameComponents;
+import com.jme3.app.SimpleApplication;
+import com.jme3.cinematic.Cinematic;
+import com.jme3.cinematic.PlayState;
+import com.jme3.input.controls.ActionListener;
+import com.jme3.input.controls.KeyTrigger;
+import java.util.ArrayList;
+
+/**
+ * A system the procedural code for the input manager.
+ *
+ * @author pavl_g
+ */
+public class KeyInputSystem implements SystemEntitiesUpdater<SimpleApplication> {
+
+    @Override
+    public ArticularSystem getAssociatedSystem() {
+        return Systems.KEY_INPUT_SYSTEM;
+    }
+
+    @Override
+    public void update(MemoryMap.EntityComponentMap entityMap, EntityComponentManager<SimpleApplication> entityComponentManager, SimpleApplication input) {
+        final Module inputs = (Module)
+                entityComponentManager.getComponent(GameComponents.INPUT_COMPONENTS.getEntity(), this);
+        // collect the data from the components
+        final ArrayList<String> mappings = new ArrayList<>();
+        inputs.getComponents().forEach((number, component) -> {
+            try {
+                final String mapping = component.getData("mapping");
+                final KeyTrigger key = component.getData("key");
+                input.getInputManager().addMapping(mapping, key);
+
+                mappings.add(mapping);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // perform operational code upon them
+        input.getInputManager().addListener((ActionListener) (name, isPressed, tpf) -> {
+            if (name.equals("start") && isPressed) {
+
+                final MemoryMap.EntityComponentMap map = entityComponentManager.getPrimaryMemoryMap().get(Systems.CINEMATIC_SYSTEM.getSystemName());
+                final Module cinematics = (Module) map.get(GameComponents.CINEMATIC_COMPONENTS.getEntity().getId().intValue());
+
+                cinematics.getComponents().forEach((number, component) -> {
+                    final Cinematic cinematic;
+                    try {
+                        cinematic = component.getData("cinematic");
+                        if(cinematic.getPlayState() != PlayState.Playing){
+                            cinematic.play();
+                        }else{
+                            cinematic.pause();
+                        }
+                    } catch (NoSuchFieldException | IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            } else if (name.equals("exit") && isPressed) {
+                System.exit(0);
+            }
+        }, mappings.toArray(new String[]{}));
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/Systems.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/Systems.java
@@ -1,0 +1,56 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.systems;
+
+import articular.core.system.ArticularSystem;
+
+/**
+ * Defines aliases for associated systems.
+ *
+ * @author pavl_g
+ */
+public enum Systems implements ArticularSystem {
+    CINEMATIC_SYSTEM(JumpKickCinematicBuilder.class.getName()),
+    KEY_INPUT_SYSTEM(KeyInputSystem.class.getName()),
+    ENV_SYSTEM(JaimeBuilder.class.getName());
+
+    private final String systemName;
+
+    Systems(final String systemName) {
+        this.systemName = systemName;
+    }
+
+    @Override
+    public String getSystemName() {
+        return systemName;
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos.jme.systems;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Articular-ES, The AvrSandbox Project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package articular.example.labs.techdemos;


### PR DESCRIPTION
`TestArticularJme` is a migration of [TestJaime.java](https://github.com/jMonkeyEngine/jmonkeyengine/blob/master/jme3-examples/src/main/java/jme3test/animation/TestJaime.java) to use Articular-ES.