### PR TITLE
Generics migration

### DIFF
--- a/articular-es/src/main/java/articular/core/component/Module.java
+++ b/articular-es/src/main/java/articular/core/component/Module.java
@@ -39,6 +39,7 @@ import articular.core.MemoryMap;
  *
  * @author pavl_g
  */
+@SuppressWarnings("unchecked")
 public interface Module extends Component {
     default void register(Component component) {
         getComponents().put(component.getId().intValue(), component);
@@ -62,8 +63,8 @@ public interface Module extends Component {
         return getComponent(component.getId()) != null;
     }
 
-    default Component getComponent(Component.Id id) {
-        return getComponents().get(id.intValue());
+    default <T extends Component> T getComponent(Component.Id id) {
+        return (T) getComponents().get(id.intValue());
     }
 
     MemoryMap.EntityComponentMap getComponents();

--- a/articular-es/src/main/java/articular/core/system/manager/CacheManager.java
+++ b/articular-es/src/main/java/articular/core/system/manager/CacheManager.java
@@ -41,6 +41,7 @@ import articular.util.Validator;
 /**
  * @author pavl_g
  */
+@SuppressWarnings("unchecked")
 public class CacheManager implements SystemManager<MemoryMap.CacheMap, MemoryMap.SystemComponentMap, Entity> {
     protected MemoryMap.CacheMap cacheMap = new MemoryMap.CacheMap();
 
@@ -90,18 +91,18 @@ public class CacheManager implements SystemManager<MemoryMap.CacheMap, MemoryMap
     }
 
     @Override
-    public Component allocateComponent(Entity entity, SystemController systemController, Component.Id id) {
+    public <T extends Component> T allocateComponent(Entity entity, SystemController systemController, Component.Id id) {
         final Component component = () -> id;
         register(entity, component, systemController);
-        return component;
+        return (T) component;
     }
 
     @Override
-    public Component getComponent(Entity entity, SystemController systemController) {
+    public <T extends Component> T getComponent(Entity entity, SystemController systemController) {
         Validator.validate(systemController, Validator.Message.ASSOCIATED_SYSTEM_NOT_FOUND);
         final MemoryMap.SystemComponentMap components = getSecondaryMemoryMap(entity);
         Validator.validate(components, Validator.Message.ASSOCIATED_SYSTEM_NOT_FOUND);
-        return components.get(systemController.getAssociatedSystem().getSystemName());
+        return (T) components.get(systemController.getAssociatedSystem().getSystemName());
     }
 
     @Override

--- a/articular-es/src/main/java/articular/core/system/manager/EntityComponentManager.java
+++ b/articular-es/src/main/java/articular/core/system/manager/EntityComponentManager.java
@@ -48,6 +48,7 @@ import java.util.Objects;
  * @see CacheManager for entity-system-component layouting
  * @see SystemController for instantiating systems
  */
+@SuppressWarnings("unchecked")
 public class EntityComponentManager<I> implements SystemManager<MemoryMap.SystemMap, MemoryMap.EntityComponentMap, SystemController> {
 
     protected MemoryMap.SystemMap systems = new MemoryMap.SystemMap();
@@ -56,10 +57,10 @@ public class EntityComponentManager<I> implements SystemManager<MemoryMap.System
     }
 
     @Override
-    public Component allocateComponent(Entity entity, SystemController systemController, Component.Id id) {
+    public <T extends Component> T allocateComponent(Entity entity, SystemController systemController, Component.Id id) {
         final Component component = () -> id;
         register(entity, component, systemController);
-        return component;
+        return (T) component;
     }
 
     public Entity createEntity(SystemController systemController, String name) {
@@ -76,11 +77,11 @@ public class EntityComponentManager<I> implements SystemManager<MemoryMap.System
     }
 
     @Override
-    public Component getComponent(Entity entity, SystemController systemController) {
+    public <T extends Component> T getComponent(Entity entity, SystemController systemController) {
         Validator.validate(entity, Validator.Message.ENTITY_NOT_FOUND);
         MemoryMap.EntityComponentMap components = getSecondaryMemoryMap(systemController);
         Validator.validate(components, Validator.Message.ASSOCIATED_ENTITY_COMPONENT_MAP_NOT_FOUND);
-        return components.get(entity.getId().intValue());
+        return (T) components.get(entity.getId().intValue());
     }
 
     @Override

--- a/articular-es/src/main/java/articular/core/system/manager/SystemManager.java
+++ b/articular-es/src/main/java/articular/core/system/manager/SystemManager.java
@@ -59,9 +59,9 @@ public interface SystemManager<P extends MemoryMap, S extends MemoryMap, K exten
 
     S allocateMemoryMap(K substrate);
 
-    Component allocateComponent(Entity entity, SystemController systemController, Component.Id id);
+    <T extends Component> T allocateComponent(Entity entity, SystemController systemController, Component.Id id);
 
-    Component getComponent(Entity entity, SystemController systemController);
+    <T extends Component> T getComponent(Entity entity, SystemController systemController);
 
     P getPrimaryMemoryMap();
 

--- a/articular-es/src/main/java/articular/util/ArticularManager.java
+++ b/articular-es/src/main/java/articular/util/ArticularManager.java
@@ -39,22 +39,23 @@ import articular.core.system.SystemController;
 import articular.core.system.manager.CacheManager;
 import articular.core.system.manager.EntityComponentManager;
 
+@SuppressWarnings("unchecked")
 public class ArticularManager<I> extends EntityComponentManager<I> {
 
     protected CacheManager cacheManager = new CacheManager();
     protected boolean enableCaching = true;
 
     @Override
-    public Component allocateComponent(Entity entity, SystemController systemController, Component.Id id) {
+    public <T extends Component> T allocateComponent(Entity entity, SystemController systemController, Component.Id id) {
         final Component component = () -> id;
         register(entity, component, systemController);
 
         if (!isEnableCaching()) {
-            return component;
+            return (T) component;
         }
         // cache to the [entity][system](component) layout
         cacheManager.register(entity, component, systemController);
-        return component;
+        return (T) component;
     }
 
     @Override

--- a/articular-examples/src/main/java/articular/example/TestArticularManager.java
+++ b/articular-examples/src/main/java/articular/example/TestArticularManager.java
@@ -120,7 +120,7 @@ public class TestArticularManager {
         public void update(MemoryMap.SystemMap systemMap, EntityComponentManager<String> entityComponentManager, String input) {
             System.out.println();
             System.out.println(input);
-            final Module module = (Module) entityComponentManager.getComponent(serialMouse, this);
+            final Module module = entityComponentManager.getComponent(serialMouse, this);
             System.out.println(module.getComponents());
         }
     }

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JaimeBuilder.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JaimeBuilder.java
@@ -61,7 +61,7 @@ public class JaimeBuilder implements SystemEntitiesUpdater<SimpleApplication> {
 
     @Override
     public void update(MemoryMap.EntityComponentMap entityMap, EntityComponentManager<SimpleApplication> entityComponentManager, SimpleApplication input) {
-        final Module env = (Module)
+        final Module env =
                 entityComponentManager.getComponent(GameComponents.JAIME.getEntity(), this);
         env.getComponents().forEach((number, component) -> {
             try {

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JumpKickCinematicBuilder.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/JumpKickCinematicBuilder.java
@@ -63,7 +63,7 @@ public class JumpKickCinematicBuilder implements SystemEntitiesUpdater<SimpleApp
     @Override
     public void update(MemoryMap.EntityComponentMap entityMap, EntityComponentManager<SimpleApplication> entityComponentManager, SimpleApplication input) {
         final Module cinematics =
-                (Module) entityComponentManager.getComponent(GameComponents.CINEMATIC_COMPONENTS.getEntity(), this);
+                entityComponentManager.getComponent(GameComponents.CINEMATIC_COMPONENTS.getEntity(), this);
         try {
             setup(input, entityComponentManager, cinematics);
         } catch (NoSuchFieldException | IllegalAccessException e) {

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/KeyInputSystem.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/systems/KeyInputSystem.java
@@ -58,7 +58,7 @@ public class KeyInputSystem implements SystemEntitiesUpdater<SimpleApplication> 
 
     @Override
     public void update(MemoryMap.EntityComponentMap entityMap, EntityComponentManager<SimpleApplication> entityComponentManager, SimpleApplication input) {
-        final Module inputs = (Module)
+        final Module inputs =
                 entityComponentManager.getComponent(GameComponents.INPUT_COMPONENTS.getEntity(), this);
         // collect the data from the components
         final ArrayList<String> mappings = new ArrayList<>();


### PR DESCRIPTION
This PR migrates the API interfaces `SystemManager` and `Module` to use upper-bounded compile-time type erasures for more flexibility of creating local variables.