### PR TITLE
articular-examples: added architecture component-diagram for TestArticularJme

### DIFF
--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/TestArticularJme.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/TestArticularJme.java
@@ -29,13 +29,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme;
+package articular.example.labs.techdemos.jme.testjaime;
 
 import articular.core.component.Component;
-import articular.example.labs.techdemos.jme.components.*;
-import articular.example.labs.techdemos.jme.systems.JumpKickCinematicBuilder;
-import articular.example.labs.techdemos.jme.systems.JaimeBuilder;
-import articular.example.labs.techdemos.jme.systems.KeyInputSystem;
+import articular.example.labs.techdemos.jme.testjaime.systems.JumpKickCinematicBuilder;
+import articular.example.labs.techdemos.jme.testjaime.components.*;
+import articular.example.labs.techdemos.jme.testjaime.systems.JaimeBuilder;
+import articular.example.labs.techdemos.jme.testjaime.systems.KeyInputSystem;
 import articular.util.ArticularManager;
 import com.jme3.app.*;
 import com.jme3.input.KeyInput;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/component-desing.puml
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/component-desing.puml
@@ -1,0 +1,44 @@
+@startuml
+'https://plantuml.com/component-diagram
+
+package "labs.techdemos.jme.testjaime.TestArticularJme" <<techdemo>> {
+    rectangle "ecsManager: ArticularManager" {
+        node "systemMap: SystemMap" <<memory-map>> #AD7FA8 {
+            node "jaimeBuilder: JaimeBuilder" <<system>> #FFFFFF {
+                node "entityMap: EntityComponentMap" <<memory-map>> #AD7FA8 {
+                    component "characters: Module" <<characters-entity>> #8AE234 {
+                        component "jaime0: Component" <<id = jaime0.getId()>>
+                        component "jaime1: Component" <<id = jaime1.getId()>>
+                        component "jaime2: Component" <<id = jaime2.getId()>>
+                        component "jaime3: Component" <<id = jaime3.getId()>>
+                    }
+                }
+                stack "   JaimeBuilder   " <<op-code>> #FCAF3E {
+                    "  JaimeBuilder#update(...)  "
+                }
+
+                "   JaimeBuilder   " <--(0 "characters: Module" : requires
+            }
+
+            node "cinematicBuilder: CinematicBuilder" <<system>> #FFFFFF {
+                node "entityMap0: EntityComponentMap" <<memory-map>> #AD7FA8 {
+                    component "cinematics: Module" <<cinematics-entity>> #8AE234 {
+                        component "cinematic0: Component" <<id = jaime0.getId()>>
+                        component "cinematic1: Component" <<id = jaime1.getId()>>
+                        component "cinematic2: Component" <<id = jaime2.getId()>>
+                        component "cinematic3: Component" <<id = jaime3.getId()>>
+                    }
+                }
+
+                stack "   CinematicBuilder   " <<op-code>> #FCAF3E {
+                "  CinematicBuilder#update(...)  "
+                }
+
+                "   CinematicBuilder   " <--(0 "cinematics: Module" : requires
+            }
+            "   CinematicBuilder   " <--(0 "characters: Module" : requires
+        }
+    }
+}
+
+@enduml

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/ComponentCollection.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/ComponentCollection.java
@@ -29,4 +29,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme;
+package articular.example.labs.techdemos.jme.testjaime.components;
+
+import articular.core.MemoryMap;
+import articular.core.component.Component;
+import articular.core.component.Module;
+
+public class ComponentCollection implements Module {
+
+    private final MemoryMap.EntityComponentMap ecsMap = new MemoryMap.EntityComponentMap();
+    private final Component.Id componentId;
+
+    public ComponentCollection(Component.Id componentId) {
+        this.componentId = componentId;
+    }
+
+    @Override
+    public Id getId() {
+        return componentId;
+    }
+
+    @Override
+    public MemoryMap.EntityComponentMap getComponents() {
+        return ecsMap;
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/GameComponents.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/GameComponents.java
@@ -29,43 +29,22 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.components;
+package articular.example.labs.techdemos.jme.testjaime.components;
 
-import articular.core.component.Component;
-import com.jme3.anim.AnimFactory;
-import com.jme3.animation.LoopMode;
-import com.jme3.cinematic.Cinematic;
-import com.jme3.cinematic.MotionPath;
-import com.jme3.math.Vector3f;
-import com.jme3.scene.Node;
+import articular.core.Entity;
 
-public class JumpKickCinematic implements Component {
+public enum GameComponents {
+    JAIME(Jaime.class.getName()),
+    CINEMATIC_COMPONENTS(JumpKickCinematic.class.getName()),
+    INPUT_COMPONENTS(InputComponent.class.getName());
 
-    private final Cinematic cinematic;
-    private final AnimFactory jumpForward = new AnimFactory(1f, "JumpForward", 30f);
-    private final AnimFactory startingPosition = new AnimFactory(0.01f, "StartingPosition", 30f);
-    private final MotionPath motionPath = new MotionPath();
+    private final String entity;
 
-    public JumpKickCinematic(final Node scene, final float initialDuration) {
-        cinematic = new Cinematic(scene, initialDuration);
-
-        jumpForward.addTimeTranslation(0, new Vector3f(0, 0, -3));
-        jumpForward.addTimeTranslation(0.35f, new Vector3f(0, 1, -1.5f));
-        jumpForward.addTimeTranslation(0.7f, new Vector3f(0, 0, 0));
-
-        motionPath.addWayPoint(new Vector3f(1.1f, 1.2f, 2.9f));
-        motionPath.addWayPoint(new Vector3f(0f, 1.2f, 3.0f));
-        motionPath.addWayPoint(new Vector3f(-1.1f, 1.2f, 2.9f));
-        // motionPath.enableDebugShape(app.getAssetManager(), app.getRootNode());
-        motionPath.setCurveTension(0.8f);
-
-        cinematic.setSpeed(1.2f);
-        cinematic.setLoopMode(LoopMode.Loop);
+    GameComponents(String entity) {
+        this.entity = entity;
     }
 
-    @Override
-    public Id getId() {
-        return new Component.Id((hashCode() >>> 16) ^
-                GameComponents.CINEMATIC_COMPONENTS.getEntity().getId().intValue());
+    public Entity getEntity() {
+        return new Entity(entity);
     }
 }

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/InputComponent.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/InputComponent.java
@@ -29,4 +29,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.components;
+package articular.example.labs.techdemos.jme.testjaime.components;
+
+import articular.core.component.Component;
+import com.jme3.input.controls.KeyTrigger;
+
+public final class InputComponent implements Component {
+
+    private final String mapping;
+    private final KeyTrigger key;
+
+    public InputComponent(String mapping, KeyTrigger key) {
+        this.mapping = mapping;
+        this.key = key;
+    }
+
+    @Override
+    public Id getId() {
+        return new Component.Id((hashCode() >>> 16) ^
+                GameComponents.INPUT_COMPONENTS.getEntity().getId().intValue());
+    }
+}

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/Jaime.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/Jaime.java
@@ -29,22 +29,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.components;
+package articular.example.labs.techdemos.jme.testjaime.components;
 
-import articular.core.Entity;
+import articular.core.component.Component;
+import com.jme3.asset.AssetManager;
+import com.jme3.light.AmbientLight;
+import com.jme3.light.PointLight;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Node;
 
-public enum GameComponents {
-    JAIME(Jaime.class.getName()),
-    CINEMATIC_COMPONENTS(JumpKickCinematic.class.getName()),
-    INPUT_COMPONENTS(InputComponent.class.getName());
+/**
+ * A composite component providing high-level object fields
+ * for the scene environment, this corresponds to the setupScene().
+ *
+ * @author pavl_g
+ */
+public final class Jaime implements Component {
 
-    private final String entity;
+    private final Node jaime;
+    private final Vector3f worldPosition;
+    private final AmbientLight ambientLight = new AmbientLight();
+    private final PointLight pointLight = new PointLight();
 
-    GameComponents(String entity) {
-        this.entity = entity;
+    public Jaime(final AssetManager assetManager, final Vector3f worldPosition) {
+        jaime = (Node) assetManager.loadModel("Models/Jaime/Jaime.j3o");
+        this.worldPosition = worldPosition;
     }
 
-    public Entity getEntity() {
-        return new Entity(entity);
+    @Override
+    public Id getId() {
+        return new Component.Id((hashCode() >>> 16) ^
+                GameComponents.JAIME.getEntity().getId().intValue());
     }
 }

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/JumpKickCinematic.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/JumpKickCinematic.java
@@ -29,28 +29,43 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.components;
+package articular.example.labs.techdemos.jme.testjaime.components;
 
-import articular.core.MemoryMap;
 import articular.core.component.Component;
-import articular.core.component.Module;
+import com.jme3.anim.AnimFactory;
+import com.jme3.animation.LoopMode;
+import com.jme3.cinematic.Cinematic;
+import com.jme3.cinematic.MotionPath;
+import com.jme3.math.Vector3f;
+import com.jme3.scene.Node;
 
-public class ComponentCollection implements Module {
+public class JumpKickCinematic implements Component {
 
-    private final MemoryMap.EntityComponentMap ecsMap = new MemoryMap.EntityComponentMap();
-    private final Component.Id componentId;
+    private final Cinematic cinematic;
+    private final AnimFactory jumpForward = new AnimFactory(1f, "JumpForward", 30f);
+    private final AnimFactory startingPosition = new AnimFactory(0.01f, "StartingPosition", 30f);
+    private final MotionPath motionPath = new MotionPath();
 
-    public ComponentCollection(Component.Id componentId) {
-        this.componentId = componentId;
+    public JumpKickCinematic(final Node scene, final float initialDuration) {
+        cinematic = new Cinematic(scene, initialDuration);
+
+        jumpForward.addTimeTranslation(0, new Vector3f(0, 0, -3));
+        jumpForward.addTimeTranslation(0.35f, new Vector3f(0, 1, -1.5f));
+        jumpForward.addTimeTranslation(0.7f, new Vector3f(0, 0, 0));
+
+        motionPath.addWayPoint(new Vector3f(1.1f, 1.2f, 2.9f));
+        motionPath.addWayPoint(new Vector3f(0f, 1.2f, 3.0f));
+        motionPath.addWayPoint(new Vector3f(-1.1f, 1.2f, 2.9f));
+        // motionPath.enableDebugShape(app.getAssetManager(), app.getRootNode());
+        motionPath.setCurveTension(0.8f);
+
+        cinematic.setSpeed(1.2f);
+        cinematic.setLoopMode(LoopMode.Loop);
     }
 
     @Override
     public Id getId() {
-        return componentId;
-    }
-
-    @Override
-    public MemoryMap.EntityComponentMap getComponents() {
-        return ecsMap;
+        return new Component.Id((hashCode() >>> 16) ^
+                GameComponents.CINEMATIC_COMPONENTS.getEntity().getId().intValue());
     }
 }

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/components/package-info.java
@@ -29,4 +29,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.systems;
+package articular.example.labs.techdemos.jme.testjaime.components;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/package-info.java
@@ -29,24 +29,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.components;
-
-import articular.core.component.Component;
-import com.jme3.input.controls.KeyTrigger;
-
-public final class InputComponent implements Component {
-
-    private final String mapping;
-    private final KeyTrigger key;
-
-    public InputComponent(String mapping, KeyTrigger key) {
-        this.mapping = mapping;
-        this.key = key;
-    }
-
-    @Override
-    public Id getId() {
-        return new Component.Id((hashCode() >>> 16) ^
-                GameComponents.INPUT_COMPONENTS.getEntity().getId().intValue());
-    }
-}
+package articular.example.labs.techdemos.jme.testjaime;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/JaimeBuilder.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/JaimeBuilder.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.systems;
+package articular.example.labs.techdemos.jme.testjaime.systems;
 
 import articular.core.MemoryMap;
 import articular.core.component.Component;
@@ -37,7 +37,7 @@ import articular.core.component.Module;
 import articular.core.system.ArticularSystem;
 import articular.core.system.SystemEntitiesUpdater;
 import articular.core.system.manager.EntityComponentManager;
-import articular.example.labs.techdemos.jme.components.GameComponents;
+import articular.example.labs.techdemos.jme.testjaime.components.GameComponents;
 import com.jme3.anim.util.AnimMigrationUtils;
 import com.jme3.app.SimpleApplication;
 import com.jme3.light.AmbientLight;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/JumpKickCinematicBuilder.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/JumpKickCinematicBuilder.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.systems;
+package articular.example.labs.techdemos.jme.testjaime.systems;
 
 import articular.core.MemoryMap;
 import articular.core.component.Component;
@@ -37,7 +37,7 @@ import articular.core.component.Module;
 import articular.core.system.ArticularSystem;
 import articular.core.system.SystemEntitiesUpdater;
 import articular.core.system.manager.EntityComponentManager;
-import articular.example.labs.techdemos.jme.components.GameComponents;
+import articular.example.labs.techdemos.jme.testjaime.components.GameComponents;
 import com.jme3.anim.AnimClip;
 import com.jme3.anim.AnimComposer;
 import com.jme3.anim.AnimFactory;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/KeyInputSystem.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/KeyInputSystem.java
@@ -29,14 +29,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.systems;
+package articular.example.labs.techdemos.jme.testjaime.systems;
 
 import articular.core.MemoryMap;
 import articular.core.component.Module;
 import articular.core.system.ArticularSystem;
 import articular.core.system.SystemEntitiesUpdater;
 import articular.core.system.manager.EntityComponentManager;
-import articular.example.labs.techdemos.jme.components.GameComponents;
+import articular.example.labs.techdemos.jme.testjaime.components.GameComponents;
 import com.jme3.app.SimpleApplication;
 import com.jme3.cinematic.Cinematic;
 import com.jme3.cinematic.PlayState;

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/Systems.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/Systems.java
@@ -29,36 +29,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.components;
+package articular.example.labs.techdemos.jme.testjaime.systems;
 
-import articular.core.component.Component;
-import com.jme3.asset.AssetManager;
-import com.jme3.light.AmbientLight;
-import com.jme3.light.PointLight;
-import com.jme3.math.Vector3f;
-import com.jme3.scene.Node;
+import articular.core.system.ArticularSystem;
 
 /**
- * A composite component providing high-level object fields
- * for the scene environment, this corresponds to the setupScene().
+ * Defines aliases for associated systems.
  *
  * @author pavl_g
  */
-public final class Jaime implements Component {
+public enum Systems implements ArticularSystem {
+    CINEMATIC_SYSTEM(JumpKickCinematicBuilder.class.getName()),
+    KEY_INPUT_SYSTEM(KeyInputSystem.class.getName()),
+    ENV_SYSTEM(JaimeBuilder.class.getName());
 
-    private final Node jaime;
-    private final Vector3f worldPosition;
-    private final AmbientLight ambientLight = new AmbientLight();
-    private final PointLight pointLight = new PointLight();
+    private final String systemName;
 
-    public Jaime(final AssetManager assetManager, final Vector3f worldPosition) {
-        jaime = (Node) assetManager.loadModel("Models/Jaime/Jaime.j3o");
-        this.worldPosition = worldPosition;
+    Systems(final String systemName) {
+        this.systemName = systemName;
     }
 
     @Override
-    public Id getId() {
-        return new Component.Id((hashCode() >>> 16) ^
-                GameComponents.JAIME.getEntity().getId().intValue());
+    public String getSystemName() {
+        return systemName;
     }
 }

--- a/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/package-info.java
+++ b/articular-examples/src/main/java/articular/example/labs/techdemos/jme/testjaime/systems/package-info.java
@@ -29,28 +29,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package articular.example.labs.techdemos.jme.systems;
-
-import articular.core.system.ArticularSystem;
-
-/**
- * Defines aliases for associated systems.
- *
- * @author pavl_g
- */
-public enum Systems implements ArticularSystem {
-    CINEMATIC_SYSTEM(JumpKickCinematicBuilder.class.getName()),
-    KEY_INPUT_SYSTEM(KeyInputSystem.class.getName()),
-    ENV_SYSTEM(JaimeBuilder.class.getName());
-
-    private final String systemName;
-
-    Systems(final String systemName) {
-        this.systemName = systemName;
-    }
-
-    @Override
-    public String getSystemName() {
-        return systemName;
-    }
-}
+package articular.example.labs.techdemos.jme.testjaime.systems;


### PR DESCRIPTION
This PR adds a software architecture that features articular-es for the _`TestArticularJme`_.